### PR TITLE
Updating Pehkui script integration and fixed "phantom" WG

### DIFF
--- a/Adipose.lua
+++ b/Adipose.lua
@@ -245,12 +245,12 @@ function adipose.setWeight(amount, forceUpdate)
 
     if oldindex ~= index or forceUpdate then
         oldindex = index
-		
-		setModelPartsVisibility(index)
-		adipose.onStageChange(amount, index, granularity, stuffed)
+
+        setModelPartsVisibility(index)
+        adipose.onStageChange(amount, index, granularity, stuffed)
     end
-	adipose.onWeightChange(amount, index, granularity, stuffed)
-	
+    adipose.onWeightChange(amount, index, granularity, stuffed)
+
     setGranularity(index, granularity)
     setStuffed(index, stuffed)
 
@@ -274,7 +274,7 @@ function adipose.adjustWeightByAmount(amount)
         adipose.minWeight, adipose.maxWeight)
     pings.AdiposeSetWeight(amount)
 end
-
+    
 --- Adjust weight by index
 ---@param amount integer Weight stage to gain (may be negative to lose weight)
 function adipose.adjustWeightByStage(amount)

--- a/Adipose.lua
+++ b/Adipose.lua
@@ -36,10 +36,19 @@ local timer = timerDuration
 -- FUNCTIONS
 adipose.onStageChange = function(_, _, _, _) end
 
+adipose.onWeightChange = function(_, _, _, _) end
+
+
 --- Set function that will be called when weight stage changes
 --- @param callback fun(weight: number, index: number, granularity: number, stuffed: number)
 function adipose.setOnStageChange(callback)
     adipose.onStageChange = callback
+end
+
+--- Set function that will be called when weight changes
+--- @param callback fun(weight: number, index: number, granularity: number, stuffed: number)
+function adipose.setOnWeightChange(callback)
+    adipose.onWeightChange = callback
 end
 
 --- Calculate weight from index
@@ -236,10 +245,12 @@ function adipose.setWeight(amount, forceUpdate)
 
     if oldindex ~= index or forceUpdate then
         oldindex = index
-        adipose.onStageChange(amount, index, granularity, stuffed)
-        setModelPartsVisibility(index)
+		
+		setModelPartsVisibility(index)
+		adipose.onStageChange(amount, index, granularity, stuffed)
     end
-
+	adipose.onWeightChange(amount, index, granularity, stuffed)
+	
     setGranularity(index, granularity)
     setStuffed(index, stuffed)
 

--- a/AdiposeHelper.lua
+++ b/AdiposeHelper.lua
@@ -58,7 +58,7 @@ end
 
 adipose.setOnStageChange( function (amount, index, granularity, stuffed)
 	for k, v in pairs(adipose.weightStages[index].scalingList) do
-		pehkui.setScale(k, v)
+		pehkui.setScale(k, v, false)
 	end
 end)
 
@@ -74,7 +74,7 @@ local function doTimer()
 end
 
 function events.tick()
-	if not doTimer() or not player:isLoaded() then return end
+	if not doTimer() or not player:isLoaded() and not player:getGamemode() == 'CREATIVE' then return end
 
 	foodQueue = foodQueue + checkFood()
 	

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Figura library that adds Weight Gain functionality with animation support.
   - [Weight Management](#weight-management)
     - [Set Weight](#setweight)
     - [Set On Stage Change](#setonstagechange)
+    - [Set On Weight Change](#setonweightchange)
     - [Set Current Weight Stage](#setcurrentweightstage)
     - [Adjust Weight By Amount](#adjustweightbyamount)
     - [Adjust Weight By Stage](#adjustweightbystage)
@@ -137,6 +138,28 @@ stuffed | `Number` | Stuffed progress
 
 ```lua
 adipose.setOnStageChange(function (weight, index, granularity stuffed)
+  -- Update UI, set Pehkui scaling, play sounds...
+  ...
+end)
+```
+
+#### `setOnWeightChange()`
+
+Lambda function which allows to write custom behavior upon weight changes.
+
+**Paramters:**
+
+Name | Type | Description
+---  | ---  | ---
+weight | `Number` | Total weight value
+index | `Number` | Weight stage index
+granularity | `Number` | Granularity progress
+stuffed | `Number` | Stuffed progress
+
+**Example:**
+
+```lua
+adipose.setOnWeightChange(function (weight, index, granularity stuffed)
   -- Update UI, set Pehkui scaling, play sounds...
   ...
 end)


### PR DESCRIPTION
I noticed while touching up the WG script that the player would gain weight regardless of the gamemode. So if a player eats in survival mode and then goes in creative mode, `foodQueue` and `roundedFoodQueue` wouldn't clear due to holding the values of the previous state.

Now the `AdiposeHelper.lua` has a check in the `events.tick` function that checks whether the player is not in creative mode (might need to add spectator mode too).

While I was at it, I fixed the integration with Pehkui as there were recent changes that introduce a `forceScale` parameter in the `setScale` command.